### PR TITLE
Rename dictionary class

### DIFF
--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -1,4 +1,4 @@
-export default class Dictioanry {
+export default class Dictionary {
     constructor() {
         this.entries = {};
     }


### PR DESCRIPTION
I fixed the typo in `lib/dictionary.js`. Tests are passing.