### PR TITLE
use backticks instead of quotes for literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,27 +81,25 @@ console.log(weatherReport(30));
 ```
 Splain templates can contain more than just a dictionary reference. 
 
-You can specify a word should be displayed as is by surrounding it with quotes (single or double), this is a literal. You could just place the word outside the template and it would be touched.
+You can specify a word should be displayed as is by surrounding it with backticks (`), this is a literal. You could just place the word outside the template and it would be touched.
 However sometimes you may want to apply some of Splains other features to a literal without it necessarily being translated through a dictionary.
 
 a | token represents an either or so will select either the pro or preceding token. 
 
 ```js
-console.log(Splain.process("hello {{'world'|'internet'}}"))
+console.log(Splain.process("hello {{`world`|`internet`}}"))
 ```
 
 Finally a ? token is a conditional. It provides a 1 in X chance of being rendered. X can be specified by providing the number after the ?.
 If no number is specified it is defaulted to 2.
 
 ```js
-console.log(Splain.process("goodbye!{{'and thanks for all the fish'?42}}"))
+console.log(Splain.process("goodbye!{{`and thanks for all the fish`?42}}"))
 ```
 
 so in the above roughly one in every 42 compiles there will be a hitchhikers guide to the galaxy reference. 
 
 see example.js (run via `node example.js`) for more examples of Splain.
-
-*note: currently sue to how literals work there is some issue with using quotes in words (there is a bug raised around this).....*
 
 ## Advanced use
 Splain templates can be built up as much as you want. dictionary items can themselves contain templates.

--- a/example.js
+++ b/example.js
@@ -20,7 +20,7 @@ Splain.addEntry({
             easy:["easy","simple","effortless"]
         },
         interesting:["interesting","appealing","delightful","engaging","compelling"],
-        veryInteresting:["{{adverbs.very adj.interesting}}", "{{adj.size.xxl'ly' adj.interesting}}"]
+        veryInteresting:["{{adverbs.very adj.interesting}}", "{{adj.size.xxl`ly` adj.interesting}}"]
     },
     adverbs:{
         speed:{
@@ -31,7 +31,7 @@ Splain.addEntry({
     }
 });
 
-let splainExplination = "{{{{greeting'.' }}?4}}Do you find making dynamic text{{{{ adverbs.very}}?4 adj.difficulty.hard}}? Using splain {{'helps'|'lets you'}} make {{adj.interesting|adj.veryInteresting}} text. Its {{adj.difficulty.easy}}";
+let splainExplination = "{{{{greeting`.`}}?4}}Do you find making dynamic text{{{{ adverbs.very}}?4 adj.difficulty.hard}}? Using splain {{`helps`|`lets you`}} make {{adj.interesting|adj.veryInteresting}} text. Its {{adj.difficulty.easy}}";
 for(let i=0; i <3; i++) {
     console.log(Splain.process(splainExplination));
 }

--- a/lib/splain.js
+++ b/lib/splain.js
@@ -23,7 +23,7 @@ export default class Splain {
                 template= `${output}`;
             }
             let compiledTemplate = executor.run(processor.getTokens(template), this.dictionary);
-            if(addQuotes) compiledTemplate = `'${compiledTemplate}'`;
+            if(addQuotes) compiledTemplate = `\`${compiledTemplate}\``;
             text = text.replace(`{{${template}}}`,compiledTemplate);
         });
 

--- a/lib/splain.test.js
+++ b/lib/splain.test.js
@@ -27,4 +27,39 @@ describe("when i use splain ", () => {
         Splain.dictionary.addEntry({test:["Splain"]});
         expect(Splain.process("{{test{{test{{test}}{{test}}}}{{test}}}}")).toBe("SplainSplainSplainSplainSplain");
     });
+
+    describe("should eb able to handle quotes in the template", ()=> {
+        beforeEach(()=>{
+            Splain.dictionary.addEntry({singleQuote:["shouldn't this work? couldn't this work?"],
+            doubleQuotes:['"should this work" he wondered'],
+            mixedQuotes:["\"don't fail me now \""]});
+
+        });
+
+        it("should be able to handle multiple single quotes",() =>{
+            expect(Splain.process("{{singleQuote}}")).toBe("shouldn't this work? couldn't this work?") ;
+        });
+
+        it("should be able to handle multiple double quotes",() =>{
+            expect(Splain.process("{{doubleQuotes}}")).toBe("\"should this work\" he wondered") ;
+        });
+
+        it("should be able to handle mixed quotes",() =>{
+            expect(Splain.process("{{mixedQuotes}}")).toBe("\"don't fail me now \"") ;
+        });
+
+        it("should be able to handle literals with quotes in", ()=>{
+            expect(Splain.process("{{`don't fail me now`}}")).toBe("don't fail me now");
+        });
+    });
+
+    it("should be able to handle a ? in a literal", () =>{
+        expect(Splain.process("{{`the ? character wont break it`}}")).toBe("the ? character wont break it");
+    });
+
+    it("should be able to handle a | in a literal", () =>{
+        expect(Splain.process("{{`the | character wont break it`}}")).toBe("the | character wont break it");
+    });
+
+
 });

--- a/lib/splain.test.js
+++ b/lib/splain.test.js
@@ -15,7 +15,7 @@ describe("when i use splain ", () => {
 
     it("should be able to handle recursive templates", () =>{
         Splain.dictionary.addEntry({test:["works"]});
-        expect(Splain.process("{{{{'it' test}}'!'}}")).toBe("it works!");
+        expect(Splain.process("{{{{`it` test}}`!`}}")).toBe("it works!");
     });
 
     it("should be able to handle multiple recursive templates", ()=>{

--- a/lib/templateFinder.test.js
+++ b/lib/templateFinder.test.js
@@ -1,13 +1,13 @@
 import finder from "./templateFinder";
 
 describe("when using the template finder", () =>{
-const testString = "Splain lets you {{adj.easy}} add some {{adj.fun}} dyamic options to you {{technology?5 | {{'work'|'project}}}}";
+const testString = "Splain lets you {{adj.easy}} add some {{adj.fun}} dyamic options to you {{technology?5 | {{`work`|`project`}}}}";
     describe("and i want to find templates", ()=> {
         it("should find all Splain templates", () => {
             expect(finder.getTemplates(testString).length).toBe(3);
             expect(finder.getTemplates(testString)[0]).toBe("{{adj.easy}}");
             expect(finder.getTemplates(testString)[1]).toBe("{{adj.fun}}");
-            expect(finder.getTemplates(testString)[2]).toBe("{{technology?5 | {{'work'|'project}}}}");
+            expect(finder.getTemplates(testString)[2]).toBe("{{technology?5 | {{`work`|`project`}}}}");
         })
     });
 

--- a/lib/templateProcessor.js
+++ b/lib/templateProcessor.js
@@ -1,6 +1,6 @@
 import Token from "./splainToken";
 
-const regToken = /[?'"|\s]/;
+const regToken = /[?`|\s]/;
 
 export default class {
 
@@ -34,8 +34,8 @@ export default class {
             if(template[0] === " " || template[0] === "\n"){
                 return new Token("blank",null,template[0])
             }
-            if(template[0] === "'" || template[0] === '"') {
-                for(;template[n]!=="'" && template[n] !== '"'  && n< template.length; n++ ) {}
+            if(template[0] === "`") {
+                for(;template[n]!=="`" && n< template.length; n++ ) {}
                 return new Token("lit", template.substring(1,n),template.substring(0,n+1));
             }
             let nextToken = template.search(regToken);

--- a/lib/templateProcessor.test.js
+++ b/lib/templateProcessor.test.js
@@ -5,7 +5,7 @@ describe("when using the finder", () => {
     describe("when finding all tokens", () => {
         let tokens = [];
         beforeEach(() => {
-            tokens = processor.getTokens(`'we'|"I" "think its " super easy?3`);
+            tokens = processor.getTokens('`we`|`I` `think its ` super easy?3');
         });
 
         it("should be able to find all the tokens", () =>{
@@ -32,7 +32,7 @@ describe("when using the finder", () => {
             });
 
             it("should default to 2 if no number is given",() => {
-                expect(processor.findNextToken("? 'test'").data).toBe("2");
+                expect(processor.findNextToken("? `test`").data).toBe("2");
             });
         });
 
@@ -62,29 +62,29 @@ describe("when using the finder", () => {
 
         describe("and the token is a literal (i.e quoted)", () => {
             it("should identify the type", () => {
-                expect(processor.findNextToken("'test'|'test2").type).toBe("lit");
+                expect(processor.findNextToken("`test`|`test2").type).toBe("lit");
             });
 
             it("should identify the literal", () => {
-                expect(processor.findNextToken("'test'|'test2").data).toBe("test");
+                expect(processor.findNextToken("`test`|`test2").data).toBe("test");
             });
 
             it("should store the raw data", () => {
-                expect(processor.findNextToken("'test'|'test2").raw).toBe("'test'");
+                expect(processor.findNextToken("`test`|`test2").raw).toBe("`test`");
             });
         });
 
         describe("and the token is a splain target", () => {
             it("should identify the type", () => {
-                expect(processor.findNextToken("morgan 'this'|shouldn't matter").type).toBe("splain");
+                expect(processor.findNextToken("morgan `this`|shouldn`t matter").type).toBe("splain");
             });
 
             it("should identify the data", () => {
-                expect(processor.findNextToken("morgan 'this'|shouldn't matter").data).toBe("morgan");
+                expect(processor.findNextToken("morgan `this`|shouldn`t matter").data).toBe("morgan");
             });
 
             it("should store the raw data", () => {
-                expect(processor.findNextToken("morgan 'this'|shouldn't matter").raw).toBe("morgan");
+                expect(processor.findNextToken("morgan `this`|shouldn`t matter").raw).toBe("morgan");
             });
 
         })

--- a/splain.js
+++ b/splain.js
@@ -202,7 +202,7 @@ var Splain = function () {
                     template = "" + output;
                 }
                 var compiledTemplate = _templateExecutor2.default.run(_templateProcessor2.default.getTokens(template), _this.dictionary);
-                if (addQuotes) compiledTemplate = "'" + compiledTemplate + "'";
+                if (addQuotes) compiledTemplate = "`" + compiledTemplate + "`";
                 text = text.replace("{{" + template + "}}", compiledTemplate);
             });
 
@@ -233,14 +233,14 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var Dictioanry = function () {
-    function Dictioanry() {
-        _classCallCheck(this, Dictioanry);
+var Dictionary = function () {
+    function Dictionary() {
+        _classCallCheck(this, Dictionary);
 
         this.entries = {};
     }
 
-    _createClass(Dictioanry, [{
+    _createClass(Dictionary, [{
         key: "addEntry",
         value: function addEntry(JSONEntry, name) {
             var _this = this;
@@ -283,10 +283,10 @@ var Dictioanry = function () {
         }
     }]);
 
-    return Dictioanry;
+    return Dictionary;
 }();
 
-exports.default = Dictioanry;
+exports.default = Dictionary;
 
 /***/ }),
 /* 4 */
@@ -296,17 +296,64 @@ exports.default = Dictioanry;
 
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 exports.default = {
-  "weather": {
-    "rain": ["drizzling", "showering", "raining", "spitting"],
-    "sun": ["sunny", "warm", "bright"]
-  },
-  "speed": {
-    "fast": ["fast", "upbeat", "quick"],
-    "slow": ["slow", "creep"]
-  }
+    adj: {
+        size: {
+            xxl: ["enormous", "massive", "gigantic", "colossal"],
+            xl: ["giant", "huge", "vast", "mammoth"],
+            l: ["big", "jumbo", "large"],
+            s: ["small", "slight"],
+            xs: ["tiny", "minuscule"]
+        },
+        temp: {
+            cold: ["cold", "freezing", "icy", "brisk", "bleak", "nippy", "chilly", "cool"],
+            warm: ["hot", "boiling", "sweltering", "roasting", "scorching", "melting", "sizzling"]
+        },
+        difficulty: {
+            hard: ["difficult", "hard", "troublesome", "tough"],
+            easy: ["easy", "simple", "effortless", "straightforward"]
+        },
+        interesting: ["interesting", "appealing", "delightful", "engaging", "compelling", "enchanting", "gripping", "fascinating", "riveting"],
+        veryInteresting: ["{{adverbs.very adj.interesting}}", "{{adj.size.xxl'ly' adj.interesting}}"],
+        speed: {
+            fast: ["fast", "upbeat", "quick", "brisk"],
+            slow: ["slow", "creep", "laggy", "crawl"]
+        }
+    },
+    adverbs: {
+        speed: {
+            fast: ["quickly", "speedily", "hastily", "rapidly", "briskly", "promptly"],
+            slow: ["slowly", "sluggishly", "unhurriedly", "lazily", "casually"]
+        },
+        very: ["very", "exceedingly", "awfully", "greatly"],
+        frequency: ["always", "usually", "normally", "often", "sometimes", "occasionally", "hardly ever", "rarely", "never"]
+    },
+    weather: {
+        rain: ["drizzling", "showering", "raining", "spitting", "pouring"],
+        sun: ["sunny", "warm", "bright"],
+        snow: ["thundersnow", "blizzard", "flurry", "snow storm", "snowsquall", "lake-effect snow", "sleet"],
+        wind: ["airstream", "breeze", "berg wind", "crosswind", "dust devil", "easterly", "gale", "gust", "headwind", "jet stream", "mistral", "monsoon", "sandstorm", "prevailing wind", "sea breeze", "sicocco", "southwester", "tail wind", "tornado", "trade wind", "turbulance", "twister", "typhoon", "whirlwind", "wind", "windstorm", "zephr"],
+        winter: ["freezing", "snowy", "icy", "slick", "frosty"]
+    },
+    genre: {
+        music: ["rock", "pop", "punk", "indie", "hip hop", "reggae", "folk", "country", "blues", "classical", "jazz"],
+        film: ["action", "adventure", "comedy", "drama", "fantasy", "horror", "thriller", "romance", "science fiction", "western"]
+    },
+    nouns: {
+        food: {
+            fruit: ["banana", "apple", "orange", "pear", "pineapple", "grapefruit", "avocado", "passionfruit", "strawberry", "kiwifruit", "grape", "peach", "cherry"],
+            desserts: ["cupcakes", "ice cream", "cookies", "brownies", "apple pie", "pumpkin pie", "cake", "cheesecake"],
+            vegetables: ['avocado', 'asparagus', 'arugula', 'beet', 'broccoli', 'brussel sprout', 'cabbage', 'carrot', 'cauliflower', 'celery', 'chard', 'collard greens', 'corn', 'kale', 'lettuce', 'mushroom', 'onion', 'pepper', 'parsley', 'rhubarb', 'parsnip', 'radish', 'spinach', 'squash', 'tomato', 'sweet potato', 'yam', 'zucchini']
+        },
+        daytime: ["morning", "afternoon", "evening", "night", "sunset", "sunrise", "dusk", "dawn"],
+        animal: ["monkey", "lion", "jaguar", "elephant", "butterfly", "ant", "pangolin", "gorilla", "dog", "cat", "bear", "snake", "mouse", "rabbit", "horse", "giraffe", "armadillo", "donkey", "wolf", "cayote", "hippo", "lion", "rhino", "aardvark", "alpaca", "cow", "moose", "crow", "deer", "dolphin", "skunk", "snail", "walrus", "whale", "zebra", "duck", "eel", "goat", "raccoon", "rat", "frog", "gopher", "chicken", "chipmonk", "panda"],
+        country: ["Afghanistan", "Albania", "Algeria", "Andorra", "Angola", "Antigua and Barbuda", "Argentina", "Armenia", "Australia", "Austria", "Azerbaijan", "Bahamas", "Bahrain", "Bangladesh", "Barbados", "Belarus", "Belgium", "Belize", "Benin", "Bhutan", "Bolivia", "Bosnia and Herzegovina", "Botswana", "Brazil", "Brunei", "Bulgaria", "Burkina Faso", "Burundi", "Cabo Verde", "Cambodia", "Cameroon", "Canada", "Central African Republic (CAR)", "Chad", "Chile", "China", "Colombia", "Comoros", "Democratic Republic of the Congo", "Republic of the Congo", "Costa Rica", "Cote d'Ivoire", "Croatia", "Cuba", "Cyprus", "Czech Republic", "Denmark", "Djibouti", "Dominica", "Dominican Republic", "Ecuador", "Egypt", "El Salvador", "Equatorial Guinea", "Eritrea", "Estonia", "Ethiopia", "Fiji", "Finland", "France", "Gabon", "Gambia", "Georgia", "Germany", "Ghana", "Greece", "Grenada", "Guatemala", "Guinea", "Guinea-Bissau", "Guyana", "Haiti", "Honduras", "Hungary", "Iceland", "India", "Indonesia", "Iran", "Iraq", "Ireland", "Israel", "Italy", "Jamaica", "Japan", "Jordan", "Kazakhstan", "Kenya", "Kiribati", "Kosovo", "Kuwait", "Kyrgyzstan", "Laos", "Latvia", "Lebanon", "Lesotho", "Liberia", "Libya", "Liechtenstein", "Lithuania", "Luxembourg", "Macedonia", "Madagascar", "Malawi", "Malaysia", "Maldives", "Mali", "Malta", "Marshall Islands", "Mauritania", "Mauritius", "Mexico", "Micronesia", "Moldova", "Monaco", "Mongolia", "Montenegro", "Morocco", "Mozambique", "Myanmar", "Namibia", "Nauru", "Nepal", "Netherlands", "New Zealand", "Nicaragua", "Niger", "Nigeria", "North Korea", "Norway", "Oman", "Pakistan", "Palau", "Palestine", "Panama", "Papua New Guinea", "Paraguay", "Peru", "Philippines", "Poland", "Portugal", "Qatar", "Romania", "Russia", "Rwanda", "Saint Kitts and Nevis", "Saint Lucia", "Saint Vincent and the Grenadines", "Samoa", "San Marino", "Sao Tome and Principe", "Saudi Arabia", "Senegal", "Serbia", "Seychelles", "Sierra Leone", "Singapore", "Slovakia", "Slovenia", "Solomon Islands", "Somalia", "South Africa", "South Korea", "South Sudan", "Spain", "Sri Lanka", "Sudan", "Suriname", "Swaziland", "Sweden", "Switzerland", "Syria", "Taiwan", "Tajikistan", "Tanzania", "Thailand", "Timor-Leste", "Togo", "Tonga", "Trinidad and Tobago", "Tunisia", "Turkey", "Turkmenistan", "Tuvalu", "Uganda", "Ukraine", "United Arab Emirates (UAE)", "United Kingdom (UK)", "United States of America (USA)", "Uruguay", "Uzbekistan", "Vanuatu", "Vatican City (Holy See)", "Venezuela", "Vietnam", "Yemen", "Zambia", "Zimbabwe"],
+        vehicle: ["ambulance", "bicycle", "boat", "bulldozer", "bus", "car", "jeep", "minibus", "motorcycle", "scooter", "sidecar", "snowplow", "tank", "taxi", "tractor", "truck"],
+        place: ["amusement park", "apartments", "beach", "church", "factory", "farm", "fire station", "hospital", "house", "library", "mosque", "park", "playground", "police station", "school", "store", "temple", "university", "zoo", "office"],
+        sport: ["football", "cricket", "basketball", "baseball", "hockey", "tennis", "volleyball", "rugby", "soccer"]
+    }
 };
 
 /***/ }),
@@ -399,7 +446,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var regToken = /[?'"|\s]/;
+var regToken = /[?`|\s]/;
 
 var _class = function () {
     function _class() {
@@ -438,8 +485,8 @@ var _class = function () {
             if (template[0] === " " || template[0] === "\n") {
                 return new _splainToken2.default("blank", null, template[0]);
             }
-            if (template[0] === "'" || template[0] === '"') {
-                for (; template[n] !== "'" && template[n] !== '"' && n < template.length; n++) {}
+            if (template[0] === "`") {
+                for (; template[n] !== "`" && n < template.length; n++) {}
                 return new _splainToken2.default("lit", template.substring(1, n), template.substring(0, n + 1));
             }
             var nextToken = template.search(regToken);


### PR DESCRIPTION
fix #4 

Decided to use ` instead of quotes. escape character wasn't really needed as ? and | are escaped when in a literal. This allows " and ' to freely be used in literals.

(n.b if using template strings in JS you will have to escape literals with \`)