### PR TITLE
Divided up `adverbs.frequencies` into appropriate groups of synonyms

### DIFF
--- a/lib/defaultDictionaries.js
+++ b/lib/defaultDictionaries.js
@@ -29,10 +29,10 @@ export default {
         },
         very: ["very", "exceedingly", "awfully", "greatly", "emininently", "absolutely", "extraordinarily", "extremely", "really"],
         frequency: {
-            always: ["always"],
-            frequently: ["usually", "normally", "often"],
+            always: ["always", "constantly"],
+            frequently: ["usually", "normally", "often", "frequently"],
             sometimes: ["sometimes", "occasionally"],
-            infrequently: ["hardly ever", "rarely"],
+            infrequently: ["hardly ever", "rarely", "seldom", "infrequently"],
             never: ["never"]
         }
     },

--- a/lib/defaultDictionaries.js
+++ b/lib/defaultDictionaries.js
@@ -28,7 +28,13 @@ export default {
             slow: ["slowly", "sluggishly", "unhurriedly", "lazily", "casually", "lackadaisically"]
         },
         very: ["very", "exceedingly", "awfully", "greatly", "emininently", "absolutely", "extraordinarily", "extremely", "really"],
-        frequency: ["always", "usually", "normally", "often", "sometimes", "occasionally", "hardly ever", "rarely", "never"]
+        frequency: {
+            always: ["always"],
+            frequently: ["usually", "normally", "often"],
+            sometimes: ["sometimes", "occasionally"],
+            infrequently: ["hardly ever", "rarely"],
+            never: ["never"]
+        }
     },
     weather: {
         rain: ["drizzling", "showering", "raining", "spitting", "pouring", "deluge"],


### PR DESCRIPTION
Since `adverbs.frequencies` contained the whole spectrum from _never_ to _always_ the words didn't feel interchangable.
This change is not backwards compatible and might break some code.

This PR relates to #12 