### PR TITLE
add tests showing or operator is ignored if no tokens either side

### DIFF
--- a/lib/templateExecutor.test.js
+++ b/lib/templateExecutor.test.js
@@ -38,13 +38,25 @@ describe("when using the template executor", ()=> {
             expect(tokens.length).toBe(2);
         });
 
+        it("should not execute if the token on the left side is null", () =>{
+            tokens = [{type:"|"},{type:"splain"},{type:"?"}];
+            executor.executeOrs(tokens);
+            expect(tokens.length).toBe(2);
+        });
+
+        it("should not execute if the token on the right side is null", () =>{
+            tokens = [{type:"splain"},{type:"?"},{type:"|"}];
+            executor.executeOrs(tokens);
+            expect(tokens.length).toBe(2);
+        });
+
         it("should remove the token if no compatible tokens exist", () =>{
             tokens = [{type:"|"}];
             executor.executeOrs(tokens);
             expect(tokens.length).toBe(0);
         });
 
-        describe("and there art multiple or tokens", ()=> {
+        describe("and there are multiple or tokens", ()=> {
             beforeEach(()=> {
                 tokens = [{type:"splain"},{type:"?"},{type:"|"},{type:"splain"},{type:"?"},{type:"|"},{type:"splain"},{type:"?"}];
             });


### PR DESCRIPTION
Seems to already be fixed, just adding tests to prove it.

closes #46

