### PR TITLE
Adding support for passing previous template resolutions into variable templates

### DIFF
--- a/lib/splain.js
+++ b/lib/splain.js
@@ -44,6 +44,7 @@ export default class Splain {
                 }
                 if (addQuotes) compiledTemplate = `\`${compiledTemplate}\``;
                 text = text.replace(`${this.config.templateTokens.opening}${template}${this.config.templateTokens.closing}`, compiledTemplate);
+                context.addTemplateResolution(template, compiledTemplate);
             });
 
         return text;

--- a/lib/splain.test.js
+++ b/lib/splain.test.js
@@ -224,11 +224,17 @@ describe("when i use splain ", () => {
     });
 
     describe("should support entries with an array of contexts", () => {
-        Splain.dictionary.addEntry({item:[{value:"Car", context:"fast"}]});
-        Splain.dictionary.addEntry({colors:[{value:"blue", context:"blue"},{value:"Racing Green", context:["green", "fast"]},{value:"turquoise", context:"blue"}]});
-        Splain.dictionary.addEntry({punc:[{value:"!", context:"green"}]});
-        expect(Splain.process("My {{item}} is {{colors}}{{punc}}")).toBe("My Car is Racing Green!");
-
+        it("should respect the array of contexts",()=> {
+            Splain.addEntry({item: [{value: "Car", context: "fast"}]});
+            Splain.addEntry({
+                colors: [{value: "blue", context: "blue"}, {
+                    value: "Racing Green",
+                    context: ["green", "fast"]
+                }, {value: "turquoise", context: "blue"}]
+            });
+            Splain.addEntry({punc: [{value: "!", context: "green"}]});
+            expect(Splain.process("My {{item}} is {{colors}}{{punc}}")).toBe("My Car is Racing Green!");
+        });
     });
 
 });

--- a/lib/splain.test.js
+++ b/lib/splain.test.js
@@ -1,7 +1,11 @@
 import splain from "./splain";
 
 describe("when i use splain ", () => {
-    let Splain = new splain();
+    let Splain;
+
+    beforeEach(()=>{
+        Splain = new splain();
+    });
 
     it("should be able to compile a sentence",()=>{
         Splain.dictionary.addEntry({test:["works"]});
@@ -177,13 +181,29 @@ describe("when i use splain ", () => {
     });
 
     describe("should be able to construct splain with custom dictionary", () => {
-        let customSplain = new splain({ customDictionary: ["customValue"] });
-        expect(customSplain.process("{{customDictionary}}")).toBe("customValue");
+        it("should handle custom dictionary",()=> {
+            let customSplain = new splain({customDictionary: ["customValue"]});
+            expect(customSplain.process("{{customDictionary}}")).toBe("customValue");
+        });
     });
 
     describe("should construct splain with default dictionary when no custom passed in", () => {
-        let customSplain = new splain();
-        expect(customSplain.process("{{nouns.animal.reptiles}}")).toBe("snake");
+        it("should use default dictionary",()=> {
+            let customSplain = new splain();
+            expect(customSplain.process("{{nouns.animal.reptiles}}")).toBe("snake");
+        });
+    });
+
+    describe("when using variable template resolution", () => {
+        it("should pass the resolutions of previous templates into the function",()=> {
+            let entry = {test:["Result"]};
+            Splain.dictionary.addEntry(entry);
+            let i = "Test ";
+            Splain.process("{{test}}{{##test}}", {
+                test: (resolutions) => i += resolutions["test"]
+            });
+            expect(i).toBe("Test Result");
+        });
     });
 
 });

--- a/lib/splainContext.js
+++ b/lib/splainContext.js
@@ -40,6 +40,22 @@ export default class SplainContext {
         this.contexts.push(context);
     }
 
+    addTemplateResolution(template, resolution) {
+        if(!this.templateResolutions) {
+            this.templateResolutions = {};
+        }
+        if (!this.templateResolutions[template]) {
+            this.templateResolutions[template] = resolution;
+        } else if (Array.isArray(this.templateResolutions[template])) {
+            this.templateResolutions[template].push(resolution);
+        } else {
+            let firstResolution = this.templateResolutions[template];
+            this.templateResolutions[template] = [];
+            this.templateResolutions[template].push(firstResolution);
+            this.templateResolutions[template].push(resolution);
+        }
+    }
+
     static getDefault() {
         return new SplainContext(new Dictionary(), new SplainConfig());
     }

--- a/lib/splainContext.test.js
+++ b/lib/splainContext.test.js
@@ -39,4 +39,19 @@ describe("with splain context", ()=> {
         });
     });
 
+    describe("when resolving templates", function() {
+        it("should set first resolution as value", () => {
+            splainContext.addTemplateResolution("template", "resolution");
+            expect(splainContext.templateResolutions["template"]).toBe("resolution");
+        });
+
+        it("should set second resolution into array of values", () => {
+            splainContext.addTemplateResolution("template", "resolution1");
+            splainContext.addTemplateResolution("template", "resolution1");
+            expect(splainContext.templateResolutions["template"].length).toBe(2);
+            expect(splainContext.templateResolutions["template"][0]).toBe("resolution1");
+            expect(splainContext.templateResolutions["template"][1]).toBe("resolution1");
+        });
+    });
+
 });

--- a/lib/splainToken.js
+++ b/lib/splainToken.js
@@ -42,7 +42,7 @@ export default class Token {
             if (context.hasOwnProperty("variables") && context.variables.hasOwnProperty(token)) {
                 let variable = context.variables[token];
                 if (typeof variable === "function") {
-                    return variable();
+                    return variable(context.templateResolutions);
                 } else {
                     return variable;
                 }


### PR DESCRIPTION
When a template is resolved we add it to the context. The first time a template is resolved the it is added to the resolutions just as a value. However if that same template is resolved again then we convert the value into an array of values for that template. This should make it a bit easier to work with if your only using a template once in a string, but still supports using it multiple times.